### PR TITLE
feat: track users likes posts

### DIFF
--- a/app/src/main/java/com/cineclubs/app/controllers/PostController.java
+++ b/app/src/main/java/com/cineclubs/app/controllers/PostController.java
@@ -20,21 +20,25 @@ public class PostController {
 
     @PostMapping
     public ResponseEntity<PostDTO> createPost(@RequestParam Long clubId,
-                                              @RequestParam String userId,
-                                              @RequestBody Post post) {
+            @RequestParam String userId,
+            @RequestBody Post post) {
         PostDTO createdPost = postService.createPost(clubId, userId, post);
         return ResponseEntity.ok(createdPost);
     }
 
     @GetMapping("/club/{clubId}")
-    public ResponseEntity<List<PostDTO>> getPostsByClub(@PathVariable Long clubId) {
-        List<PostDTO> posts = postService.getPostsForClub(clubId);
+    public ResponseEntity<List<PostDTO>> getPostsByClub(
+            @PathVariable Long clubId,
+            @RequestParam(required = false) String userId) {
+        List<PostDTO> posts = postService.getPostsForClub(clubId, userId);
         return ResponseEntity.ok(posts);
     }
 
     @GetMapping("/{postId}")
-    public ResponseEntity<PostDTO> getPostById(@PathVariable Long postId) {
-        PostDTO post = postService.getPostById(postId);
+    public ResponseEntity<PostDTO> getPostById(
+            @PathVariable Long postId,
+            @RequestParam String userId) {
+        PostDTO post = postService.getPostById(postId, userId);
         return ResponseEntity.ok(post);
     }
 

--- a/app/src/main/java/com/cineclubs/app/dto/ClubDTO.java
+++ b/app/src/main/java/com/cineclubs/app/dto/ClubDTO.java
@@ -34,7 +34,7 @@ public class ClubDTO {
 
         if (includePosts && club.getPosts() != null) {
             this.posts = club.getPosts().stream()
-                    .map(post -> new PostDTO(post, false))
+                    .map(PostDTO::new)
                     .collect(Collectors.toList());
         }
 

--- a/app/src/main/java/com/cineclubs/app/dto/PostDTO.java
+++ b/app/src/main/java/com/cineclubs/app/dto/PostDTO.java
@@ -15,27 +15,43 @@ public class PostDTO {
     private String clubName;
     private int commentsCount;
     private int likesCount;
+    private boolean hasLiked;
 
-    public PostDTO(Post post, boolean includeAuthor) {
+    public PostDTO(Post post, String currentUserId) {
         this.id = post.getId();
         this.title = post.getTitle();
         this.content = post.getContent();
         this.createdAt = post.getCreatedAt();
 
-        if (includeAuthor) {
-            this.authorId = post.getAuthor().getuserId();
-            this.authorName = post.getAuthor().getUsername();
-            this.authorImageUrl = post.getAuthor().getImageUrl();
-        }
+        this.authorId = post.getAuthor().getuserId();
+        this.authorName = post.getAuthor().getUsername();
+        this.authorImageUrl = post.getAuthor().getImageUrl();
 
         this.clubId = post.getClub().getId();
         this.clubName = post.getClub().getName();
         this.commentsCount = post.getComments() != null ? post.getComments().size() : 0;
         this.likesCount = post.getLikes() != null ? post.getLikes().size() : 0;
+
+        this.hasLiked = post.getLikes() != null &&
+                post.getLikes().stream().anyMatch(user -> user.getuserId().equals(currentUserId));
     }
 
     public PostDTO(Post post) {
-        this(post, true);
+        this.id = post.getId();
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.createdAt = post.getCreatedAt();
+
+        this.authorId = post.getAuthor().getuserId();
+        this.authorName = post.getAuthor().getUsername();
+        this.authorImageUrl = post.getAuthor().getImageUrl();
+
+        this.clubId = post.getClub().getId();
+        this.clubName = post.getClub().getName();
+        this.commentsCount = post.getComments() != null ? post.getComments().size() : 0;
+        this.likesCount = post.getLikes() != null ? post.getLikes().size() : 0;
+
+        this.hasLiked = false;
     }
 
     public Long getId() {
@@ -124,6 +140,14 @@ public class PostDTO {
 
     public void setLikesCount(int likesCount) {
         this.likesCount = likesCount;
+    }
+
+    public boolean isHasLiked() {
+        return hasLiked;
+    }
+
+    public void setHasLiked(boolean hasLiked) {
+        this.hasLiked = hasLiked;
     }
 
 }

--- a/app/src/main/java/com/cineclubs/app/models/Post.java
+++ b/app/src/main/java/com/cineclubs/app/models/Post.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.Set;
+import java.util.HashSet;
 
 @Entity
 @Table(name = "posts")
@@ -34,17 +35,14 @@ public class Post {
     private Set<Comment> comments;
 
     @ManyToMany
-    @JoinTable(
-            name = "post_likes",
-            joinColumns = @JoinColumn(name = "post_id"),
-            inverseJoinColumns = @JoinColumn(name = "user_id")
-    )
-    private Set<User> likes; // Users who liked the post
+    @JoinTable(name = "post_likes", joinColumns = @JoinColumn(name = "post_id"), inverseJoinColumns = @JoinColumn(name = "user_id"))
+    private Set<User> likes = new HashSet<>();
 
     public Post() {
     }
 
-    public Post(Long id, String title, String content, LocalDateTime createdAt, User author, Club club, Set<Comment> comments, Set<User> likes) {
+    public Post(Long id, String title, String content, LocalDateTime createdAt, User author, Club club,
+            Set<Comment> comments, Set<User> likes) {
         this.id = id;
         this.title = title;
         this.content = content;
@@ -121,7 +119,8 @@ public class Post {
 
     @Override
     public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null || getClass() != o.getClass())
+            return false;
         Post post = (Post) o;
         return Objects.equals(id, post.id);
     }
@@ -131,4 +130,3 @@ public class Post {
         return Objects.hashCode(id);
     }
 }
-

--- a/app/src/main/java/com/cineclubs/app/services/PostService.java
+++ b/app/src/main/java/com/cineclubs/app/services/PostService.java
@@ -46,16 +46,15 @@ public class PostService {
                 .toList();
     }
 
-    public PostDTO getPostById(Long id) {
+    public PostDTO getPostById(Long id, String currentUserId) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Post not found with id: " + id));
-        return new PostDTO(post);
+        return new PostDTO(post, currentUserId);
     }
 
-    public List<PostDTO> getPostsForClub(Long clubId) {
-        clubService.getClubById(clubId);
+    public List<PostDTO> getPostsForClub(Long clubId, String currentUserId) {
         return postRepository.findByClubId(clubId).stream()
-                .map(PostDTO::new)
+                .map(post -> currentUserId != null ? new PostDTO(post, currentUserId) : new PostDTO(post))
                 .toList();
     }
 


### PR DESCRIPTION
# Add hasLiked Field to PostDTO

## Changes
- Added `hasLiked` boolean field to PostDTO to track user-specific like status
- Added two constructors in PostDTO to handle both authenticated and unauthenticated users
- Updated PostDTO to calculate hasLiked based on current user's ID

## Testing
- Authenticated user can see their like status (hasLiked: true/false)
- Unauthenticated user always sees hasLiked: false
- Like counts remain visible for all users

## API Response Example
```json
{
  "id": 1,
  "title": "Post Title",
  // ... other fields ...
  "likesCount": 5,
  "hasLiked": true  // or false based on current user
}
```