### PR TITLE
feat: configure seeding database

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,28 +13,33 @@ This platform fosters a vibrant community for fans of movies and TV shows, offer
 ## ✨ Core Features
 
 ### **Club Management**
+
 - Create, update, and delete clubs.
 - Configure clubs as **public** (open to all) or **private** (invite-only).
 - Detailed club profiles include:
   - Club name.
   - Description.
   - Banner image.
+
 ---
 
 ### **Join and Leave Clubs**
+
 - Users can **join** or **leave** clubs.
 - Display a list of clubs the user is a member of on their profile.
 
 ---
 
 ### **Club Discussions**
+
 - Create **discussion threads** within a club.
 - Enable **replies** to threads for detailed conversations.
-- Allow moderators to **pin important threads** (e.g., *Weekly Watch Recommendations*).
+- Allow moderators to **pin important threads** (e.g., _Weekly Watch Recommendations_).
 
 ---
 
 ### **Club Moderation**
+
 - Club owners or moderators have tools to:
   - **Remove members** who violate club rules.
   - **Delete inappropriate posts or threads**.
@@ -43,6 +48,7 @@ This platform fosters a vibrant community for fans of movies and TV shows, offer
 ---
 
 ### **Member Activity Tracking**
+
 - Track active members and their contributions:
   - Threads started.
   - Posts made.
@@ -51,13 +57,15 @@ This platform fosters a vibrant community for fans of movies and TV shows, offer
 ---
 
 ### **Notifications**
+
 - Notify members about:
   - New threads in clubs they've joined.
   - Invitations to join private clubs.
-  
+
 ---
 
 ## 🛠️ Technologies Used
+
 - **Frontend**: React, Tailwind CSS, React Router.
 - **Backend**: SpringBoot, PostgreSQL.
 - **Authentication**: Clerk for user management.
@@ -66,6 +74,23 @@ This platform fosters a vibrant community for fans of movies and TV shows, offer
 ---
 
 ## 🚧 Future Enhancements
+
 - Add **real-time chat** for live discussions.
 - Support for **movie/TV tracking** within clubs.
 - Advanced **search and filtering** for discovering clubs.
+
+## 💾 Database Seeding
+
+Populate the database with sample data for development:
+
+```bash
+# Windows
+.\db.bat seed        # Seed database
+.\db.bat seed:force  # Force reseed (adds more data)
+
+# Linux/macOS
+./db.sh seed        # Seed database
+./db.sh seed:force  # Force reseed (adds more data)
+```
+
+Creates sample users, clubs, posts... for testing.

--- a/app/db.bat
+++ b/app/db.bat
@@ -1,0 +1,28 @@
+@echo off
+setlocal
+
+if "%1"=="" (
+    echo Available commands:
+    echo   seed         Seed the database
+    echo   seed:force   Force reseed the database
+    echo   help         Show this help message
+    exit /b 1
+)
+
+set COMMAND=--help
+if "%1"=="seed" (
+    set COMMAND=--seed
+)
+if "%1"=="seed:force" (
+    set COMMAND=--seed --force
+)
+if "%1"=="help" (
+    set COMMAND=--help
+)
+
+call mvnw compile exec:java ^
+    -Dexec.mainClass="com.cineclubs.app.cli.DatabaseSeederMain" ^
+    -Dexec.args="%COMMAND%" ^
+    -Dspring.profiles.active=seed
+
+endlocal

--- a/app/db.sh
+++ b/app/db.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Show help if no arguments provided
+if [ -z "$1" ]; then
+    echo "Available commands:"
+    echo "  seed         Seed the database"
+    echo "  seed:force   Force reseed the database"
+    echo "  help         Show this help message"
+    exit 1
+fi
+
+# Set default command
+COMMAND="--help"
+
+# Parse command argument
+case "$1" in
+    "seed") COMMAND="--seed" ;;
+    "seed:force") COMMAND="--seed --force" ;;
+    "help") COMMAND="--help" ;;
+esac
+
+# Execute maven command
+./mvnw compile exec:java \
+    -Dexec.mainClass="com.cineclubs.app.cli.DatabaseSeederMain" \
+    -Dexec.args="$COMMAND" \
+    -Dspring.profiles.active=seed

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -92,6 +92,11 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.github.javafaker</groupId>
+			<artifactId>javafaker</artifactId>
+			<version>1.0.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -100,12 +105,21 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
+					<mainClass>com.cineclubs.app.AppApplication</mainClass>
 					<excludes>
 						<exclude>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
 						</exclude>
 					</excludes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>3.1.0</version>
+				<configuration>
+					<mainClass>com.cineclubs.app.cli.DatabaseSeederMain</mainClass>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/app/src/main/java/com/cineclubs/app/cli/DatabaseSeederCommand.java
+++ b/app/src/main/java/com/cineclubs/app/cli/DatabaseSeederCommand.java
@@ -1,0 +1,51 @@
+package com.cineclubs.app.cli;
+
+import java.util.Arrays;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.context.annotation.Profile;
+import com.cineclubs.app.seeder.DatabaseSeeder;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@Profile("!prod")
+@RequiredArgsConstructor
+public class DatabaseSeederCommand implements CommandLineRunner {
+    private final DatabaseSeeder databaseSeeder;
+
+    @Override
+    public void run(String... args) {
+        if (args.length == 0)
+            return;
+
+        switch (args[0]) {
+            case "--seed":
+                handleSeed(args);
+                break;
+            case "--help":
+                printHelp();
+                break;
+        }
+    }
+
+    private void handleSeed(String... args) {
+        boolean force = Arrays.asList(args).contains("--force");
+        try {
+            System.out.println("Starting database seeding...");
+            databaseSeeder.seed(force);
+            System.out.println("Database seeding completed successfully!");
+        } catch (Exception e) {
+            System.err.println("Error seeding database: " + e.getMessage());
+            System.exit(1);
+        }
+        System.exit(0);
+    }
+
+    private void printHelp() {
+        System.out.println("Available commands:");
+        System.out.println("  --seed        Seed the database");
+        System.out.println("  --seed --force Force reseed even if database is not empty");
+        System.out.println("  --help        Show this help message");
+    }
+}

--- a/app/src/main/java/com/cineclubs/app/cli/DatabaseSeederMain.java
+++ b/app/src/main/java/com/cineclubs/app/cli/DatabaseSeederMain.java
@@ -1,0 +1,20 @@
+package com.cineclubs.app.cli;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@SpringBootApplication
+@ComponentScan(basePackages = "com.cineclubs.app")
+@EntityScan("com.cineclubs.app.models")
+@EnableJpaRepositories("com.cineclubs.app.repository")
+public class DatabaseSeederMain {
+    public static void main(String[] args) {
+        SpringApplication app = new SpringApplication(DatabaseSeederMain.class);
+        app.setWebApplicationType(WebApplicationType.NONE);
+        app.run(args);
+    }
+}

--- a/app/src/main/java/com/cineclubs/app/config/DataSeederConfig.java
+++ b/app/src/main/java/com/cineclubs/app/config/DataSeederConfig.java
@@ -1,0 +1,15 @@
+package com.cineclubs.app.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import lombok.Data;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "seeder")
+public class DataSeederConfig {
+    private int userCount = 10;
+    private int clubCount = 5;
+    private int postCount = 20;
+    private boolean enabled = true;
+}

--- a/app/src/main/java/com/cineclubs/app/seeder/DatabaseSeeder.java
+++ b/app/src/main/java/com/cineclubs/app/seeder/DatabaseSeeder.java
@@ -1,0 +1,168 @@
+package com.cineclubs.app.seeder;
+
+import com.github.javafaker.Faker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import com.cineclubs.app.config.DataSeederConfig;
+import com.cineclubs.app.models.*;
+import com.cineclubs.app.repository.*;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Component
+@Profile("!prod")
+public class DatabaseSeeder {
+    private static final Logger logger = LoggerFactory.getLogger(DatabaseSeeder.class);
+
+    private final UserRepository userRepository;
+    private final ClubRepository clubRepository;
+    private final PostRepository postRepository;
+    private final DataSeederConfig seederConfig;
+    private final Faker faker;
+
+    private static final String[] PROFILE_IMAGES = {
+            "https://images.unsplash.com/photo-1535713875002-d1d0cf377fde",
+            "https://images.unsplash.com/photo-1494790108377-be9c29b29330",
+            "https://images.unsplash.com/photo-1527980965255-d3b416303d12",
+            "https://images.unsplash.com/photo-1438761681033-6461ffad8d80",
+            "https://images.unsplash.com/photo-1472099645785-5658abf4ff4e"
+    };
+
+    private static final String[] CLUB_COVER_IMAGES = {
+            "https://images.unsplash.com/photo-1489599849927-2ee91cede3ba",
+            "https://images.unsplash.com/photo-1517604931442-7e0c8ed2963c",
+            "https://images.unsplash.com/photo-1440404653325-ab127d49abc1",
+            "https://images.unsplash.com/photo-1536440136628-849c177e76a1",
+            "https://images.unsplash.com/photo-1478720568477-152d9b164e26"
+    };
+
+    public DatabaseSeeder(
+            UserRepository userRepository,
+            ClubRepository clubRepository,
+            PostRepository postRepository,
+            DataSeederConfig seederConfig) {
+        this.userRepository = userRepository;
+        this.clubRepository = clubRepository;
+        this.postRepository = postRepository;
+        this.seederConfig = seederConfig;
+        this.faker = new Faker();
+    }
+
+    @Transactional
+    public void seed(boolean force) {
+        if (!force && isDatabaseSeeded()) {
+            logger.warn("Database is already seeded. Use --force to reseed.");
+            return;
+        }
+
+        logger.info("Starting database seeding...");
+        try {
+            List<User> users = seedUsers();
+            List<Club> clubs = seedClubs(users);
+            seedPosts(users, clubs);
+
+            logger.info("Database seeding completed successfully!");
+        } catch (Exception e) {
+            logger.error("Error seeding database: {}", e.getMessage(), e);
+            throw new RuntimeException("Database seeding failed", e);
+        }
+    }
+
+    private boolean isDatabaseSeeded() {
+        return userRepository.count() > 0;
+    }
+
+    @Transactional
+    protected List<User> seedUsers() {
+        logger.info("Seeding {} users...", seederConfig.getUserCount());
+        List<User> users = createUsers(seederConfig.getUserCount());
+        return userRepository.saveAll(users);
+    }
+
+    @Transactional
+    protected List<Club> seedClubs(List<User> users) {
+        logger.info("Seeding {} clubs...", seederConfig.getClubCount());
+        List<Club> clubs = createClubs(seederConfig.getClubCount(), users);
+        return clubRepository.saveAll(clubs);
+    }
+
+    @Transactional
+    protected List<Post> seedPosts(List<User> users, List<Club> clubs) {
+        logger.info("Seeding {} posts...", seederConfig.getPostCount());
+        List<Post> posts = createPosts(seederConfig.getPostCount(), users, clubs);
+        return postRepository.saveAll(posts);
+    }
+
+    private List<User> createUsers(int count) {
+        List<User> users = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            User user = new User();
+            user.setuserId(UUID.randomUUID().toString());
+            user.setEmail(faker.internet().emailAddress());
+            user.setFirstName(faker.name().firstName());
+            user.setLastName(faker.name().lastName());
+            user.setImageUrl(PROFILE_IMAGES[i % PROFILE_IMAGES.length] + "?w=150&h=150&fit=crop");
+            user.setUsername(faker.name().username());
+            user.setCreatedAt(LocalDateTime.now());
+            user.setUpdatedAt(LocalDateTime.now());
+            users.add(user);
+        }
+        return users;
+    }
+
+    private List<Club> createClubs(int count, List<User> users) {
+        List<Club> clubs = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            Club club = new Club();
+            club.setName(generateClubName());
+            club.setDescription(generateClubDescription());
+            club.setImageUrl(CLUB_COVER_IMAGES[i % CLUB_COVER_IMAGES.length] + "?w=1200&h=630&fit=crop");
+            club.setUser(users.get(faker.random().nextInt(users.size())));
+            club.setMembers(new HashSet<>(users.subList(0, faker.random().nextInt(2, users.size()))));
+            clubs.add(club);
+        }
+        return clubs;
+    }
+
+    private List<Post> createPosts(int count, List<User> users, List<Club> clubs) {
+        List<Post> posts = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            Post post = new Post();
+            post.setTitle(faker.book().title());
+            post.setContent(faker.lorem().paragraph());
+            post.setCreatedAt(LocalDateTime.now());
+            post.setAuthor(users.get(faker.random().nextInt(users.size())));
+            post.setClub(clubs.get(faker.random().nextInt(clubs.size())));
+            post.setLikes(new HashSet<>(users.subList(0, faker.random().nextInt(users.size()))));
+            posts.add(post);
+        }
+        return posts;
+    }
+
+    private String generateClubName() {
+        String[] prefixes = { "Classic", "Modern", "International", "Indie", "Documentary" };
+        String[] suffixes = { "Film Society", "Cinema Club", "Movie Buffs", "Film Collective", "Cinephiles" };
+        return prefixes[faker.random().nextInt(prefixes.length)] + " " +
+                suffixes[faker.random().nextInt(suffixes.length)];
+    }
+
+    private String generateClubDescription() {
+        String[] templates = {
+                "A community dedicated to exploring %s cinema and fostering meaningful discussions about film.",
+                "Join us in celebrating the art of %s filmmaking through screenings, discussions, and events.",
+                "A gathering place for enthusiasts of %s movies to share their passion and insights.",
+                "Discover and discuss the best of %s cinema with fellow movie lovers.",
+                "A vibrant community for fans of %s films to connect and share their perspectives."
+        };
+        String[] genres = { "classic", "contemporary", "independent", "international", "avant-garde" };
+
+        String template = templates[faker.random().nextInt(templates.length)];
+        String genre = genres[faker.random().nextInt(genres.length)];
+
+        return String.format(template, genre);
+    }
+}

--- a/app/src/main/resources/application-seed.properties
+++ b/app/src/main/resources/application-seed.properties
@@ -1,0 +1,17 @@
+# Database
+spring.datasource.url=jdbc:postgresql://localhost:5432/cineclubs
+spring.datasource.username=postgres
+spring.datasource.password=password
+
+# JPA / Hibernate
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+# Disable web server
+spring.main.web-application-type=none
+
+# Seeder configuration
+seeder.enabled=true
+seeder.user-count=10
+seeder.club-count=5
+seeder.post-count=20


### PR DESCRIPTION
# Add Database Seeding Feature for Development Environment

## Overview
Added a comprehensive database seeding system to streamline development and testing by populating the database with realistic sample data. This feature is only available in non-production environments.

## Key Features
- Configurable seeding for Users, Clubs, and Posts entities
- CLI commands for easy database seeding
- Realistic data generation using JavaFaker
- Cross-platform support with both Shell and Batch scripts
- Force reseed option for database reset

## Technical Details
- Added `DatabaseSeeder` class for core seeding logic
- Implemented configurable seeding parameters via `DataSeederConfig`
- Created CLI interface with `DatabaseSeederCommand` and `DatabaseSeederMain`
- Added convenience scripts (`db.sh` and `db.bat`) for easy execution
- Profile-based activation (`@Profile("!prod")`) to prevent production use

## Usage
```bash
# On Unix-like systems
./db.sh seed         # Seed empty database
./db.sh seed:force   # Force reseed existing data
./db.sh help         # Show help

# On Windows
db.bat seed
db.bat seed:force
db.bat help
```

## Configuration
Default seeding parameters in `application.properties`:
- 10 users
- 5 clubs
- 20 posts

These can be customized by overriding the `seeder.*` properties.

## Testing
- Verified seeding functionality in local development environment
- Tested both initial seeding and force reseed scenarios
- Confirmed proper relationship creation between entities
- Validated profile-based activation

## Security Considerations
- Seeding is disabled in production environment through profile checks
- Sample data includes no sensitive information
- Uses randomized UUIDs for user IDs

## Related Issues
Closes #7 